### PR TITLE
FI-3636 Fix typo in description and add links to test suite

### DIFF
--- a/lib/smart_health_cards_test_kit.rb
+++ b/lib/smart_health_cards_test_kit.rb
@@ -35,6 +35,10 @@ module SmartHealthCardsTestKit
       {
         label: 'Download',
         url: 'https://github.com/inferno-framework/smart-health-cards-test-kit/releases'
+      },
+      {
+        label: 'SMART Health Cards Framework',
+        url: 'https://spec.smarthealth.cards/'
       }
     ]
 

--- a/lib/smart_health_cards_test_kit.rb
+++ b/lib/smart_health_cards_test_kit.rb
@@ -19,10 +19,24 @@ module SmartHealthCardsTestKit
     id :smart_health_cards
     title 'SMART Health Cards'
     description %(
-      The US Core Test Kit tests systems for their conformance to the
+      The SMART Health Cards Test Kit tests systems for their conformance to the
       [SMART Health Cards Framework v1.4.0](https://spec.smarthealth.cards/)
     )
     version VERSION
+    links [
+      {
+        label: 'Report Issue',
+        url: 'https://github.com/inferno-framework/smart-health-cards-test-kit/issues'
+      },
+      {
+        label: 'Open Source',
+        url: 'https://github.com/inferno-framework/smart-health-cards-test-kit'
+      },
+      {
+        label: 'Download',
+        url: 'https://github.com/inferno-framework/smart-health-cards-test-kit/releases'
+      }
+    ]
 
     # All FHIR validation requsets will use this FHIR validator
     fhir_resource_validator do


### PR DESCRIPTION
# Summary

This PR fixed a typo in test suite description, also add some useful links to the test suite

# Testing Guidance
Verify test suite description has the correct "The SMART Health Cards Test Kit"
Verify "Report Issue", "Open Source", "Download", and "SMART Health Cards Framework" links are shown at the page footer

