### PR TITLE
Fi 3759 save bundles from credential strings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,6 +191,8 @@ GEM
     nio4r (2.7.4)
     nokogiri (1.18.2-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.18.2-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.18.2-x86_64-linux-gnu)
       racc (~> 1.4)
     oauth2 (1.4.11)
@@ -256,6 +258,7 @@ GEM
       rack (>= 2.2.4)
       redis-client (>= 0.19.0)
     sqlite3 (1.7.3-arm64-darwin)
+    sqlite3 (1.7.3-x86_64-darwin)
     sqlite3 (1.7.3-x86_64-linux)
     stringio (3.1.0)
     strings (0.2.1)
@@ -286,6 +289,7 @@ GEM
 
 PLATFORMS
   arm64-darwin
+  x86_64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/smart_health_cards_test_kit/shc_fhir_validation.rb
+++ b/lib/smart_health_cards_test_kit/shc_fhir_validation.rb
@@ -7,33 +7,15 @@ module SmartHealthCardsTestKit
     description %(
       SMART Health Card payload SHALL be a valid FHIR Bundle resource
     )
-    input :credential_strings
-    output :fhir_bundles
+    input :fhir_bundles
 
     run do
+      
+      #skip_if fhir_bundles.blank?, 'No FHIR bundles received'
+      jsonArray = JSON.parse(fhir_bundles)
+      jsonArray.each { |json| assert_valid_resource(resource: FHIR::Bundle.new(json)) }
+      #fhir_bundles.each { |bundle| assert_valid_resource(resource: bundle) }
 
-      skip_if credential_strings.blank?, 'No Verifiable Credentials received'
-      bundle_array = []
-
-      credential_strings.split(',').each do |credential|
-        jws = SmartHealthCardsTestKit::Utils::JWS.from_jws(credential)
-        payload = payload_from_jws(jws)
-
-        vc = payload['vc']
-        assert vc.is_a?(Hash), "Expected 'vc' claim to be a JSON object, but found #{vc.class}"
-
-        subject = vc['credentialSubject']
-        assert subject.is_a?(Hash), "Expected 'vc.credentialSubject' to be a JSON object, but found #{subject.class}"
-
-        raw_bundle = subject['fhirBundle']
-        assert raw_bundle.is_a?(Hash), "Expected 'vc.fhirBundle' to be a JSON object, but found #{raw_bundle.class}"
-
-        bundle = FHIR::Bundle.new(raw_bundle)
-        assert_valid_resource(resource: bundle)
-        bundle_array.append(bundle)
-
-      end
-      output fhir_bundles: bundle_array
     end
   end
 end

--- a/lib/smart_health_cards_test_kit/shc_fhir_validation.rb
+++ b/lib/smart_health_cards_test_kit/shc_fhir_validation.rb
@@ -10,12 +10,10 @@ module SmartHealthCardsTestKit
     input :fhir_bundles
 
     run do
-      
-      #skip_if fhir_bundles.blank?, 'No FHIR bundles received'
-      jsonArray = JSON.parse(fhir_bundles)
-      jsonArray.each { |json| assert_valid_resource(resource: FHIR::Bundle.new(json)) }
-      #fhir_bundles.each { |bundle| assert_valid_resource(resource: bundle) }
 
+      #skip_if fhir_bundles.blank?, 'No FHIR bundles received'
+      hash_array = eval(fhir_bundles)
+      hash_array.each { |hash| assert_valid_resource(resource: FHIR::Bundle.new(hash)) }
     end
   end
 end

--- a/lib/smart_health_cards_test_kit/shc_payload_verification.rb
+++ b/lib/smart_health_cards_test_kit/shc_payload_verification.rb
@@ -38,6 +38,7 @@ module SmartHealthCardsTestKit
     run do
       skip_if credential_strings.blank?, 'No Verifiable Credentials received'
       decompressed_payload_array = []
+      fhir_bundles = []
 
       credential_strings.split(',').each do |credential|
         jws = SmartHealthCardsTestKit::Utils::JWS.from_jws(credential)
@@ -80,6 +81,7 @@ module SmartHealthCardsTestKit
         end
 
         bundle = FHIR::Bundle.new(raw_bundle)
+        fhir_bundles.append(bundle)
         resources = bundle.entry.map(&:resource)
         bundle.entry.each { |entry| entry.resource = nil }
         resources << bundle

--- a/lib/smart_health_cards_test_kit/shc_payload_verification.rb
+++ b/lib/smart_health_cards_test_kit/shc_payload_verification.rb
@@ -80,7 +80,7 @@ module SmartHealthCardsTestKit
         end
 
         bundle = FHIR::Bundle.new(raw_bundle)
-        fhir_bundles.append(bundle.to_json)
+        fhir_bundles.append(raw_bundle)
         resources = bundle.entry.map(&:resource)
         bundle.entry.each { |entry| entry.resource = nil }
         resources << bundle

--- a/lib/smart_health_cards_test_kit/shc_payload_verification.rb
+++ b/lib/smart_health_cards_test_kit/shc_payload_verification.rb
@@ -80,7 +80,7 @@ module SmartHealthCardsTestKit
         end
 
         bundle = FHIR::Bundle.new(raw_bundle)
-        fhir_bundles.append(bundle)
+        fhir_bundles.append(bundle.to_json)
         resources = bundle.entry.map(&:resource)
         bundle.entry.each { |entry| entry.resource = nil }
         resources << bundle

--- a/lib/smart_health_cards_test_kit/shc_payload_verification.rb
+++ b/lib/smart_health_cards_test_kit/shc_payload_verification.rb
@@ -37,7 +37,6 @@ module SmartHealthCardsTestKit
 
     run do
       skip_if credential_strings.blank?, 'No Verifiable Credentials received'
-      decompressed_payload_array = []
       fhir_bundles = []
 
       credential_strings.split(',').each do |credential|
@@ -119,7 +118,7 @@ module SmartHealthCardsTestKit
           end
         end
       end
-      output fhir_bundles: decompressed_payload_array
+      output fhir_bundles: fhir_bundles
     end
   end
 end

--- a/lib/smart_health_cards_test_kit/shc_payload_verification.rb
+++ b/lib/smart_health_cards_test_kit/shc_payload_verification.rb
@@ -33,7 +33,7 @@ module SmartHealthCardsTestKit
           (e.g., `{"patient": {"reference": "resource:0"}}`)
     )
     input :credential_strings
-    output :decompressed_payloads
+    output :fhir_bundles
 
     run do
       skip_if credential_strings.blank?, 'No Verifiable Credentials received'
@@ -117,7 +117,7 @@ module SmartHealthCardsTestKit
           end
         end
       end
-      output decompressed_payloads: decompressed_payload_array
+      output fhir_bundles: decompressed_payload_array
     end
   end
 end

--- a/spec/smart_health_cards_test_kit/shc_fhir_validation_spec.rb
+++ b/spec/smart_health_cards_test_kit/shc_fhir_validation_spec.rb
@@ -35,24 +35,28 @@ RSpec.describe SmartHealthCardsTestKit::SHCFHIRValidation do
         .to_return(status: 200, body: operation_outcome_success.to_json)
     end
 
+    it 'passes for a valid fhir bundle' do
+      
+    end
+
     #TODO: update text with specific bundle type
     it 'passes if the JWS payload conforms to the FHIR Bundle profile' do
-      credential_strings = 'eyJ6aXAiOiJERUYiLCJhbGciOiJFUzI1NiIsImtpZCI6IjRIVWIyYXJ2aFRTWHNzRW9NczJHNVRvRHBzWXZzajdoNXdUXzN6TkV0dWcifQ.hVLLjtQwEPyX5pqHk5nMI0fggoQAwcIFzcFxOhMjx45sJ2JY5d9pJ7tktLuz5BLZrq6uqu57kM5BCa33fZmmygiuWuN8uWGMQQS6aqDM9hu22xd5nkUwCijvwV96hPLnXOaoznXc-ha58m0iuK3dm-UQhwPR3MYJM8o6O76KkV03aPmHe2k0nCIQFmvUXnL1bah-ofBBUtNK-wOtC5gStglLMiINt28HXStcZYMwSlFVQEZARPZCXohhUOq7VQSw6MxgBZYhgsdDINC8wwXLO6moDD5y62aesxxRh0y-ctEiNYDTRForSWbecx_6ZsddFrMszo9XtHeLpi_kjqTANEUvKsmeKHGe-8HNZrpeoccQ88iFkBrfmXrGCFNLfZ71uovz2K2DbtU-MfachnxSJ-tUjL-JQMyVkLMDTKcpgv5BFZFZbNCiDt2v8yGQEWKw81PweSe7hSLfxhkju0SrjP80dBXaEEK-2Ra7_fMEPlxP-VYM-a0YGqm5-ufgVe_KSC2C-9VwwYrtId4vpt26VLdNY9OEFRpf8pwV8yzUME-CV4r-xNH7_whz2nRYJ1I3JnUkYJ3Hjm0OBWPHReCT4D5XDu34mNvp2fvD_k_0_QU.-jNkrXCHlq75fLCGvD8_7eF4iQ-XYQT7uZyiZ1Fqa33-ZQA1-aVEk519JZYGMDdJpO-mVqIC20Xh9sBsD8COzg'
-      result = run(test, { file_download_url: url, url: url, credential_strings: credential_strings})
+      fhir_bundles = '[{"type":"collection", "entry":[{"fullUrl":"resource:0", "resource":{"name":[{"family":"Rowe", "given":["Corrina"]}], "birthDate":"1971-12-06", "resourceType":"Patient"}}, {"fullUrl":"resource:1", "resource":{"status":"completed", "vaccineCode":{"coding":[{"system":"http://hl7.org/fhir/sid/cvx", "code":"207"}]}, "patient":{"reference":"resource:0"}, "occurrenceDateTime":"2025-02-05", "lotNumber":"1234567", "resourceType":"Immunization"}}], "resourceType":"Bundle"}]'
+      result = run(test, { file_download_url: url, url: url, fhir_bundles: fhir_bundles})
       expect(result.result).to eq('pass')
     end
 
-    it 'passes if a comma-separated list of VCs all contain JWS payloads that conform to the FHIR Bundle profile' do
-      credential_strings = 'eyJ6aXAiOiJERUYiLCJhbGciOiJFUzI1NiIsImtpZCI6IjRIVWIyYXJ2aFRTWHNzRW9NczJHNVRvRHBzWXZzajdoNXdUXzN6TkV0dWcifQ.hVLLjtQwEPyX5pqHk5nMI0fggoQAwcIFzcFxOhMjx45sJ2JY5d9pJ7tktLuz5BLZrq6uqu57kM5BCa33fZmmygiuWuN8uWGMQQS6aqDM9hu22xd5nkUwCijvwV96hPLnXOaoznXc-ha58m0iuK3dm-UQhwPR3MYJM8o6O76KkV03aPmHe2k0nCIQFmvUXnL1bah-ofBBUtNK-wOtC5gStglLMiINt28HXStcZYMwSlFVQEZARPZCXohhUOq7VQSw6MxgBZYhgsdDINC8wwXLO6moDD5y62aesxxRh0y-ctEiNYDTRForSWbecx_6ZsddFrMszo9XtHeLpi_kjqTANEUvKsmeKHGe-8HNZrpeoccQ88iFkBrfmXrGCFNLfZ71uovz2K2DbtU-MfachnxSJ-tUjL-JQMyVkLMDTKcpgv5BFZFZbNCiDt2v8yGQEWKw81PweSe7hSLfxhkju0SrjP80dBXaEEK-2Ra7_fMEPlxP-VYM-a0YGqm5-ufgVe_KSC2C-9VwwYrtId4vpt26VLdNY9OEFRpf8pwV8yzUME-CV4r-xNH7_whz2nRYJ1I3JnUkYJ3Hjm0OBWPHReCT4D5XDu34mNvp2fvD_k_0_QU.-jNkrXCHlq75fLCGvD8_7eF4iQ-XYQT7uZyiZ1Fqa33-ZQA1-aVEk519JZYGMDdJpO-mVqIC20Xh9sBsD8COzg,eyJ6aXAiOiJERUYiLCJhbGciOiJFUzI1NiIsImtpZCI6IjRIVWIyYXJ2aFRTWHNzRW9NczJHNVRvRHBzWXZzajdoNXdUXzN6TkV0dWcifQ.fZDBTsMwEET_ZbkmaUJatfURVT0jFbigHhxnWxs5drV2IoUq_866oUJCAt_WfjOe2SuYEECAjvEiFgvrlbTahyjqsiwhA9ecQFTruqrrzWa1zGBQIK4QxwuCeL_JAutCJylqlDbqQklqw8M85Glgm7855QfTVtt_GdN1vTOfMhrv4JiBImzRRSPtoW8-UMUU6aQNvSGFxAhYFmVRsWm6fepda_EnNihvLasSmQEb0chd2KG39pUsA4TB96RQpBXch2TgZIczKztjWQZ7EzQSY2czoEs7OXiSo4TjxEkbw1V2MqZfq-3jKi_X-a3s3fRlTvTM3TgITEn06-07_sTnCw.pYwsdxlzdXVhnPzO_YDlMXnSHHz88XA3A9bGuzutySq2v3tO5lOWsfsOQGhoWiH7LCtUNpoizX5GSi5cXVI19g'
-      result = run(test, { file_download_url: url, url: url, credential_strings: credential_strings})
+    #it 'passes if a comma-separated list of VCs all contain JWS payloads that conform to the FHIR Bundle profile' do
+    #  credential_strings = 'eyJ6aXAiOiJERUYiLCJhbGciOiJFUzI1NiIsImtpZCI6IjRIVWIyYXJ2aFRTWHNzRW9NczJHNVRvRHBzWXZzajdoNXdUXzN6TkV0dWcifQ.hVLLjtQwEPyX5pqHk5nMI0fggoQAwcIFzcFxOhMjx45sJ2JY5d9pJ7tktLuz5BLZrq6uqu57kM5BCa33fZmmygiuWuN8uWGMQQS6aqDM9hu22xd5nkUwCijvwV96hPLnXOaoznXc-ha58m0iuK3dm-UQhwPR3MYJM8o6O76KkV03aPmHe2k0nCIQFmvUXnL1bah-ofBBUtNK-wOtC5gStglLMiINt28HXStcZYMwSlFVQEZARPZCXohhUOq7VQSw6MxgBZYhgsdDINC8wwXLO6moDD5y62aesxxRh0y-ctEiNYDTRForSWbecx_6ZsddFrMszo9XtHeLpi_kjqTANEUvKsmeKHGe-8HNZrpeoccQ88iFkBrfmXrGCFNLfZ71uovz2K2DbtU-MfachnxSJ-tUjL-JQMyVkLMDTKcpgv5BFZFZbNCiDt2v8yGQEWKw81PweSe7hSLfxhkju0SrjP80dBXaEEK-2Ra7_fMEPlxP-VYM-a0YGqm5-ufgVe_KSC2C-9VwwYrtId4vpt26VLdNY9OEFRpf8pwV8yzUME-CV4r-xNH7_whz2nRYJ1I3JnUkYJ3Hjm0OBWPHReCT4D5XDu34mNvp2fvD_k_0_QU.-jNkrXCHlq75fLCGvD8_7eF4iQ-XYQT7uZyiZ1Fqa33-ZQA1-aVEk519JZYGMDdJpO-mVqIC20Xh9sBsD8COzg,eyJ6aXAiOiJERUYiLCJhbGciOiJFUzI1NiIsImtpZCI6IjRIVWIyYXJ2aFRTWHNzRW9NczJHNVRvRHBzWXZzajdoNXdUXzN6TkV0dWcifQ.fZDBTsMwEET_ZbkmaUJatfURVT0jFbigHhxnWxs5drV2IoUq_866oUJCAt_WfjOe2SuYEECAjvEiFgvrlbTahyjqsiwhA9ecQFTruqrrzWa1zGBQIK4QxwuCeL_JAutCJylqlDbqQklqw8M85Glgm7855QfTVtt_GdN1vTOfMhrv4JiBImzRRSPtoW8-UMUU6aQNvSGFxAhYFmVRsWm6fepda_EnNihvLasSmQEb0chd2KG39pUsA4TB96RQpBXch2TgZIczKztjWQZ7EzQSY2czoEs7OXiSo4TjxEkbw1V2MqZfq-3jKi_X-a3s3fRlTvTM3TgITEn06-07_sTnCw.pYwsdxlzdXVhnPzO_YDlMXnSHHz88XA3A9bGuzutySq2v3tO5lOWsfsOQGhoWiH7LCtUNpoizX5GSi5cXVI19g'
+    #  result = run(test, { file_download_url: url, url: url, credential_strings: credential_strings})
 
-      expect(result.result).to eq('pass')
-    end
+    #  expect(result.result).to eq('pass')
+    #end
 
-    it 'raises an error if the JWS payload does not conform to the FHIR Bundle profile' do
-      credential_strings = 'asdf'
-      expect {result = run(test, { file_download_url: url, url: url, credential_strings: credential_strings })}.to raise_error()
-    end
+    #it 'raises an error if the JWS payload does not conform to the FHIR Bundle profile' do
+    #  credential_strings = 'asdf'
+    #  expect {result = run(test, { file_download_url: url, url: url, credential_strings: credential_strings })}.to raise_error()
+    #end
 
   end
 

--- a/spec/smart_health_cards_test_kit/shc_fhir_validation_spec.rb
+++ b/spec/smart_health_cards_test_kit/shc_fhir_validation_spec.rb
@@ -29,6 +29,47 @@ RSpec.describe SmartHealthCardsTestKit::SHCFHIRValidation do
         sessionId: 'b8cf5547-1dc7-4714-a797-dc2347b93fe2'
       }
     end
+    let(:fhir_bundles) do
+      FHIR::Bundle.new(
+        type: 'collection',
+        entry: [
+          {
+            fullUrl: 'resource:0',
+            resource: {
+              name: [
+                {
+                  family: 'Rowe',
+                  given: ['Corrina']
+                }
+              ],
+              birthDate: '1971-12-06',
+              resourceType: 'Patient'
+            }
+          },
+          {
+            fullUrl: 'resource:1',
+            resource: {
+              status: 'completed',
+              vaccineCode: {
+                coding: [
+                  {
+                    system: 'http://hl7.org/fhir/sid/cvx',
+                    code: '207'
+                  }
+                ]
+              },
+              patient: {
+                reference: 'resource:0'
+              },
+              occurrenceDateTime: '2025-02-05',
+              lotNumber: '1234567',
+              resourceType: 'Immunization'
+            }
+          }
+        ],
+        resourceType: 'Bundle'
+      )
+    end
 
     before do
       stub_request(:post, "https://example.com/validatorapi/validate")
@@ -36,13 +77,12 @@ RSpec.describe SmartHealthCardsTestKit::SHCFHIRValidation do
     end
 
     it 'passes for a valid fhir bundle' do
-      
+
     end
 
     #TODO: update text with specific bundle type
     it 'passes if the JWS payload conforms to the FHIR Bundle profile' do
-      fhir_bundles = '[{"type":"collection", "entry":[{"fullUrl":"resource:0", "resource":{"name":[{"family":"Rowe", "given":["Corrina"]}], "birthDate":"1971-12-06", "resourceType":"Patient"}}, {"fullUrl":"resource:1", "resource":{"status":"completed", "vaccineCode":{"coding":[{"system":"http://hl7.org/fhir/sid/cvx", "code":"207"}]}, "patient":{"reference":"resource:0"}, "occurrenceDateTime":"2025-02-05", "lotNumber":"1234567", "resourceType":"Immunization"}}], "resourceType":"Bundle"}]'
-      result = run(test, { file_download_url: url, url: url, fhir_bundles: fhir_bundles})
+      result = run(test, { file_download_url: url, url: url, fhir_bundles: [ fhir_bundles.to_hash ]})
       expect(result.result).to eq('pass')
     end
 

--- a/spec/smart_health_cards_test_kit/shc_fhir_validation_spec.rb
+++ b/spec/smart_health_cards_test_kit/shc_fhir_validation_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe SmartHealthCardsTestKit::SHCFHIRValidation do
         sessionId: 'b8cf5547-1dc7-4714-a797-dc2347b93fe2'
       }
     end
-    let(:fhir_bundles) do
+    let(:fhir_bundle_corrina_rowe) do
       FHIR::Bundle.new(
         type: 'collection',
         entry: [
@@ -71,33 +71,72 @@ RSpec.describe SmartHealthCardsTestKit::SHCFHIRValidation do
       )
     end
 
+    let (:fhir_bundle_deanne_gleichner) do
+      FHIR::Bundle.new(
+        type: 'collection',
+        entry: [
+          {
+            fullUrl: 'resource:0',
+            resource: {
+              name: [
+                {
+                  family: 'Gleichner',
+                  given: [
+                    'Deanne'
+                  ]
+                }
+              ],
+              birthDate: '2007-04-11',
+              resourceType: 'Patient'
+            }
+          },
+          {
+            fullUrl: 'resource:1',
+            resource: {
+              status: 'completed',
+              vaccineCode: {
+                coding: [
+                  {
+                    system: 'http://hl7.org/fhir/sid/cvx',
+                    code: '210'
+                  }
+                ]
+              },
+              patient: {
+                reference: 'resource:0'
+              },
+              occurrenceDateTime: '2025-02-04',
+              lotNumber: '1234567',
+              resourceType: 'Immunization'
+            }
+          }
+        ],
+        resourceType: 'Bundle'
+      )
+    end
+
     before do
       stub_request(:post, "https://example.com/validatorapi/validate")
         .to_return(status: 200, body: operation_outcome_success.to_json)
     end
 
-    it 'passes for a valid fhir bundle' do
-
-    end
-
-    #TODO: update text with specific bundle type
-    it 'passes if the JWS payload conforms to the FHIR Bundle profile' do
-      result = run(test, { file_download_url: url, url: url, fhir_bundles: [ fhir_bundles.to_hash ]})
+    it 'passes if the input is an array with a single bundle conforms to the FHIR Bundle profile' do
+      result = run(test, { file_download_url: url, url: url, fhir_bundles: [ fhir_bundle_corrina_rowe.to_hash ]})
       expect(result.result).to eq('pass')
     end
 
-    #it 'passes if a comma-separated list of VCs all contain JWS payloads that conform to the FHIR Bundle profile' do
-    #  credential_strings = 'eyJ6aXAiOiJERUYiLCJhbGciOiJFUzI1NiIsImtpZCI6IjRIVWIyYXJ2aFRTWHNzRW9NczJHNVRvRHBzWXZzajdoNXdUXzN6TkV0dWcifQ.hVLLjtQwEPyX5pqHk5nMI0fggoQAwcIFzcFxOhMjx45sJ2JY5d9pJ7tktLuz5BLZrq6uqu57kM5BCa33fZmmygiuWuN8uWGMQQS6aqDM9hu22xd5nkUwCijvwV96hPLnXOaoznXc-ha58m0iuK3dm-UQhwPR3MYJM8o6O76KkV03aPmHe2k0nCIQFmvUXnL1bah-ofBBUtNK-wOtC5gStglLMiINt28HXStcZYMwSlFVQEZARPZCXohhUOq7VQSw6MxgBZYhgsdDINC8wwXLO6moDD5y62aesxxRh0y-ctEiNYDTRForSWbecx_6ZsddFrMszo9XtHeLpi_kjqTANEUvKsmeKHGe-8HNZrpeoccQ88iFkBrfmXrGCFNLfZ71uovz2K2DbtU-MfachnxSJ-tUjL-JQMyVkLMDTKcpgv5BFZFZbNCiDt2v8yGQEWKw81PweSe7hSLfxhkju0SrjP80dBXaEEK-2Ra7_fMEPlxP-VYM-a0YGqm5-ufgVe_KSC2C-9VwwYrtId4vpt26VLdNY9OEFRpf8pwV8yzUME-CV4r-xNH7_whz2nRYJ1I3JnUkYJ3Hjm0OBWPHReCT4D5XDu34mNvp2fvD_k_0_QU.-jNkrXCHlq75fLCGvD8_7eF4iQ-XYQT7uZyiZ1Fqa33-ZQA1-aVEk519JZYGMDdJpO-mVqIC20Xh9sBsD8COzg,eyJ6aXAiOiJERUYiLCJhbGciOiJFUzI1NiIsImtpZCI6IjRIVWIyYXJ2aFRTWHNzRW9NczJHNVRvRHBzWXZzajdoNXdUXzN6TkV0dWcifQ.fZDBTsMwEET_ZbkmaUJatfURVT0jFbigHhxnWxs5drV2IoUq_866oUJCAt_WfjOe2SuYEECAjvEiFgvrlbTahyjqsiwhA9ecQFTruqrrzWa1zGBQIK4QxwuCeL_JAutCJylqlDbqQklqw8M85Glgm7855QfTVtt_GdN1vTOfMhrv4JiBImzRRSPtoW8-UMUU6aQNvSGFxAhYFmVRsWm6fepda_EnNihvLasSmQEb0chd2KG39pUsA4TB96RQpBXch2TgZIczKztjWQZ7EzQSY2czoEs7OXiSo4TjxEkbw1V2MqZfq-3jKi_X-a3s3fRlTvTM3TgITEn06-07_sTnCw.pYwsdxlzdXVhnPzO_YDlMXnSHHz88XA3A9bGuzutySq2v3tO5lOWsfsOQGhoWiH7LCtUNpoizX5GSi5cXVI19g'
-    #  result = run(test, { file_download_url: url, url: url, credential_strings: credential_strings})
+    it 'passes if the input is an array of multiple bundles that all conform to the FHIR Bundle profile' do
+      fhir_bundles = []
+      fhir_bundles.append(fhir_bundle_corrina_rowe.to_hash)
+      fhir_bundles.append(fhir_bundle_deanne_gleichner.to_hash)
+      result = run(test, { file_download_url: url, url: url, fhir_bundles: fhir_bundles})
+      expect(result.result).to eq('pass')
+    end
 
-    #  expect(result.result).to eq('pass')
-    #end
-
-    #it 'raises an error if the JWS payload does not conform to the FHIR Bundle profile' do
-    #  credential_strings = 'asdf'
-    #  expect {result = run(test, { file_download_url: url, url: url, credential_strings: credential_strings })}.to raise_error()
-    #end
+    it 'raises an error if the input does not conform to the FHIR Bundle profile' do
+      result = run(test, { file_download_url: url, url: url, fhir_bundles: 'asdf'})
+      expect(result.result).to eq('error')
+    end
 
   end
-
 end


### PR DESCRIPTION
# Summary
save fhir_bundles and use as input to the shc_fhir_validation test to avoid duplicating the work of decoding verifiable credential string

# Testing Guidance
run unit tests, run test kit in browser and test with health_cards reference server
