### PR TITLE
FI-3759 Change input for validation module from credential string to FHIR Bundle hash input parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,17 @@
 # Inferno Smart Health Card Test Kit
 
 This is an [Inferno](https://inferno-framework.github.io/) test kit
-for the SMART Health Cards Framework [v1.4.0](https://spec.smarthealth.cards/)
+for the SMART Health Cards Framework [v1.4.0](https://spec.smarthealth.cards/).
+
+The test kit currently tests the following requirements:
+
+- Download and validate a health card via file download
+- Download and validate a health card via FHIR $health-cards-issue operation
+- Download and validate a health card via QR Code scanning
+
+It does **NOT** support this requirement:
+
+- Download and validate a health card via DeepLink
 
 ## Instructions
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,12 @@ This is an [Inferno](https://inferno-framework.github.io/) test kit
 for the SMART Health Cards Framework [v1.4.0](https://spec.smarthealth.cards/).
 
 The test kit currently tests the following requirements:
+- Download and validate a health card [via File Download](https://spec.smarthealth.cards/#via-file-download)
+- Download and validate a health card [via FHIR $health-cards-issue Operation](https://spec.smarthealth.cards/#via-fhir-health-cards-issue-operation)
+- Download and validate a health card [via QR Code (Print or Scan)](https://spec.smarthealth.cards/#via-qr-print-or-scan)
 
-- Download and validate a health card via file download
-- Download and validate a health card via FHIR $health-cards-issue operation
-- Download and validate a health card via QR Code scanning
-
-It does **NOT** support this requirement:
-
-- Download and validate a health card via DeepLink
+The test kit does **NOT** test this requirement:
+- Download and validate a health card [via Deep Link](https://spec.smarthealth.cards/#via-deep-link)
 
 ## Instructions
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ for the SMART Health Cards Framework [v1.4.0](https://spec.smarthealth.cards/).
 The test kit currently tests the following requirements:
 - Download and validate a health card [via File Download](https://spec.smarthealth.cards/#via-file-download)
 - Download and validate a health card [via FHIR $health-cards-issue Operation](https://spec.smarthealth.cards/#via-fhir-health-cards-issue-operation)
-- Download and validate a health card [via QR Code (Print or Scan)](https://spec.smarthealth.cards/#via-qr-print-or-scan)
+- Download and validate a health card [via QR Code](https://spec.smarthealth.cards/#via-qr-print-or-scan)
 
 The test kit does **NOT** test this requirement:
 - Download and validate a health card [via Deep Link](https://spec.smarthealth.cards/#via-deep-link)

--- a/lib/smart_health_cards_test_kit/metadata.rb
+++ b/lib/smart_health_cards_test_kit/metadata.rb
@@ -21,9 +21,12 @@ module SmartHealthCardsTestKit
       These tests are intended to allow server implementers to perform checks of their server against SMART Health Cards Framework requrirements.
 
       The test kit currently tests the following requirements:
-      - Download and validate a health card via file download
-      - Download and validate a health card via FHIR $health-cards-issue operation
-      - Download and validate a health card via QR Code scanning
+      - Download and validate a health card [via File Download](https://spec.smarthealth.cards/#via-file-download)
+      - Download and validate a health card [via FHIR $health-cards-issue Operation](https://spec.smarthealth.cards/#via-fhir-health-cards-issue-operation)
+      - Download and validate a health card [via QR Code](https://spec.smarthealth.cards/#via-qr-print-or-scan)
+
+      The test kit does **NOT** test this requirement:
+      - Download and validate a health card [via Deep Link](https://spec.smarthealth.cards/#via-deep-link)
 
       See the test descriptions within the test kit for detail on the specific validations performed as part of testing these requirements.
 

--- a/lib/smart_health_cards_test_kit/shc_fhir_validation.rb
+++ b/lib/smart_health_cards_test_kit/shc_fhir_validation.rb
@@ -7,33 +7,15 @@ module SmartHealthCardsTestKit
     description %(
       SMART Health Card payload SHALL be a valid FHIR Bundle resource
     )
-    input :credential_strings
-    output :fhir_bundles
+    input :fhir_bundles
 
     run do
+      
+      #skip_if fhir_bundles.blank?, 'No FHIR bundles received'
+      jsonArray = JSON.parse(fhir_bundles)
+      jsonArray.each { |json| assert_valid_resource(resource: FHIR::Bundle.new(json)) }
+      #fhir_bundles.each { |bundle| assert_valid_resource(resource: bundle) }
 
-      skip_if credential_strings.blank?, 'No Verifiable Credentials received'
-      bundle_array = []
-
-      credential_strings.split(',').each do |credential|
-        jws = SmartHealthCardsTestKit::Utils::JWS.from_jws(credential)
-        payload = payload_from_jws(jws)
-
-        vc = payload['vc']
-        assert vc.is_a?(Hash), "Expected 'vc' claim to be a JSON object, but found #{vc.class}"
-
-        subject = vc['credentialSubject']
-        assert subject.is_a?(Hash), "Expected 'vc.credentialSubject' to be a JSON object, but found #{subject.class}"
-
-        raw_bundle = subject['fhirBundle']
-        assert raw_bundle.is_a?(Hash), "Expected 'vc.fhirBundle' to be a JSON object, but found #{raw_bundle.class}"
-
-        bundle = FHIR::Bundle.new(raw_bundle)
-        assert_valid_resource(resource: bundle)
-        bundle_array.append(bundle)
-
-      end
-      output fhir_bundles: bundle_array
     end
   end
 end

--- a/lib/smart_health_cards_test_kit/shc_fhir_validation.rb
+++ b/lib/smart_health_cards_test_kit/shc_fhir_validation.rb
@@ -11,10 +11,14 @@ module SmartHealthCardsTestKit
 
     run do
       skip_if fhir_bundles.blank?, 'No FHIR bundles received'
+
+      assert_valid_json(fhir_bundles)
       bundle_array = JSON.parse(fhir_bundles)
+
+      skip_if bundle_array.blank?, 'No FHIR bundles received'
+
       bundle_array.each do |bundle|
-        assert_valid_json(bundle)
-        assert_valid_resource(resource: FHIR.from_contents(bundle))
+        assert_valid_resource(resource: FHIR::Bundle.new(bundle))
       end
     end
   end

--- a/lib/smart_health_cards_test_kit/shc_fhir_validation.rb
+++ b/lib/smart_health_cards_test_kit/shc_fhir_validation.rb
@@ -11,8 +11,11 @@ module SmartHealthCardsTestKit
 
     run do
       skip_if fhir_bundles.blank?, 'No FHIR bundles received'
-      hash_array = eval(fhir_bundles)
-      hash_array.each { |hash| assert_valid_resource(resource: FHIR::Bundle.new(hash)) }
+      bundle_array = JSON.parse(fhir_bundles)
+      bundle_array.each do |bundle|
+        assert_valid_json(bundle)
+        assert_valid_resource(resource: FHIR.from_contents(bundle))
+      end
     end
   end
 end

--- a/lib/smart_health_cards_test_kit/shc_fhir_validation.rb
+++ b/lib/smart_health_cards_test_kit/shc_fhir_validation.rb
@@ -10,12 +10,10 @@ module SmartHealthCardsTestKit
     input :fhir_bundles
 
     run do
-      
-      #skip_if fhir_bundles.blank?, 'No FHIR bundles received'
-      jsonArray = JSON.parse(fhir_bundles)
-      jsonArray.each { |json| assert_valid_resource(resource: FHIR::Bundle.new(json)) }
-      #fhir_bundles.each { |bundle| assert_valid_resource(resource: bundle) }
 
+      #skip_if fhir_bundles.blank?, 'No FHIR bundles received'
+      hash_array = eval(fhir_bundles)
+      hash_array.each { |hash| assert_valid_resource(resource: FHIR::Bundle.new(hash)) }
     end
   end
 end

--- a/lib/smart_health_cards_test_kit/shc_fhir_validation.rb
+++ b/lib/smart_health_cards_test_kit/shc_fhir_validation.rb
@@ -7,13 +7,11 @@ module SmartHealthCardsTestKit
     description %(
       SMART Health Card payload SHALL be a valid FHIR Bundle resource
     )
-    input :fhir_bundles
 
     run do
-
-      #skip_if fhir_bundles.blank?, 'No FHIR bundles received'
-      hash_array = eval(fhir_bundles)
-      hash_array.each { |hash| assert_valid_resource(resource: FHIR::Bundle.new(hash)) }
+      fhir_bundles = scratch[:bundles]
+      skip_if fhir_bundles.blank?, 'No FHIR bundles received'
+      fhir_bundles.each { |bundle| assert_valid_resource(resource: bundle)}
     end
   end
 end

--- a/lib/smart_health_cards_test_kit/shc_fhir_validation.rb
+++ b/lib/smart_health_cards_test_kit/shc_fhir_validation.rb
@@ -7,11 +7,12 @@ module SmartHealthCardsTestKit
     description %(
       SMART Health Card payload SHALL be a valid FHIR Bundle resource
     )
+    input :fhir_bundles
 
     run do
-      fhir_bundles = scratch[:bundles]
       skip_if fhir_bundles.blank?, 'No FHIR bundles received'
-      fhir_bundles.each { |bundle| assert_valid_resource(resource: bundle)}
+      hash_array = eval(fhir_bundles)
+      hash_array.each { |hash| assert_valid_resource(resource: FHIR::Bundle.new(hash)) }
     end
   end
 end

--- a/lib/smart_health_cards_test_kit/shc_payload_verification.rb
+++ b/lib/smart_health_cards_test_kit/shc_payload_verification.rb
@@ -38,6 +38,7 @@ module SmartHealthCardsTestKit
     run do
       skip_if credential_strings.blank?, 'No Verifiable Credentials received'
       decompressed_payload_array = []
+      fhir_bundles = []
 
       credential_strings.split(',').each do |credential|
         jws = SmartHealthCardsTestKit::Utils::JWS.from_jws(credential)
@@ -80,6 +81,7 @@ module SmartHealthCardsTestKit
         end
 
         bundle = FHIR::Bundle.new(raw_bundle)
+        fhir_bundles.append(bundle)
         resources = bundle.entry.map(&:resource)
         bundle.entry.each { |entry| entry.resource = nil }
         resources << bundle

--- a/lib/smart_health_cards_test_kit/shc_payload_verification.rb
+++ b/lib/smart_health_cards_test_kit/shc_payload_verification.rb
@@ -80,7 +80,7 @@ module SmartHealthCardsTestKit
         end
 
         bundle = FHIR::Bundle.new(raw_bundle)
-        fhir_bundles.append(raw_bundle)
+        fhir_bundles.append(bundle.to_json)
         resources = bundle.entry.map(&:resource)
         bundle.entry.each { |entry| entry.resource = nil }
         resources << bundle

--- a/lib/smart_health_cards_test_kit/shc_payload_verification.rb
+++ b/lib/smart_health_cards_test_kit/shc_payload_verification.rb
@@ -80,7 +80,7 @@ module SmartHealthCardsTestKit
         end
 
         bundle = FHIR::Bundle.new(raw_bundle)
-        fhir_bundles.append(raw_bundle)
+        fhir_bundles.append(bundle)
         resources = bundle.entry.map(&:resource)
         bundle.entry.each { |entry| entry.resource = nil }
         resources << bundle
@@ -119,7 +119,6 @@ module SmartHealthCardsTestKit
         end
       end
       scratch[:bundles] = fhir_bundles
-      output fhir_bundles: fhir_bundles
     end
   end
 end

--- a/lib/smart_health_cards_test_kit/shc_payload_verification.rb
+++ b/lib/smart_health_cards_test_kit/shc_payload_verification.rb
@@ -80,7 +80,7 @@ module SmartHealthCardsTestKit
         end
 
         bundle = FHIR::Bundle.new(raw_bundle)
-        fhir_bundles.append(bundle.to_hash)
+        fhir_bundles.append(raw_bundle)
         resources = bundle.entry.map(&:resource)
         bundle.entry.each { |entry| entry.resource = nil }
         resources << bundle

--- a/lib/smart_health_cards_test_kit/shc_payload_verification.rb
+++ b/lib/smart_health_cards_test_kit/shc_payload_verification.rb
@@ -80,7 +80,7 @@ module SmartHealthCardsTestKit
         end
 
         bundle = FHIR::Bundle.new(raw_bundle)
-        fhir_bundles.append(bundle.to_json)
+        fhir_bundles.append(raw_bundle)
         resources = bundle.entry.map(&:resource)
         bundle.entry.each { |entry| entry.resource = nil }
         resources << bundle

--- a/lib/smart_health_cards_test_kit/shc_payload_verification.rb
+++ b/lib/smart_health_cards_test_kit/shc_payload_verification.rb
@@ -80,7 +80,7 @@ module SmartHealthCardsTestKit
         end
 
         bundle = FHIR::Bundle.new(raw_bundle)
-        fhir_bundles.append(bundle)
+        fhir_bundles.append(bundle.to_json)
         resources = bundle.entry.map(&:resource)
         bundle.entry.each { |entry| entry.resource = nil }
         resources << bundle

--- a/lib/smart_health_cards_test_kit/shc_payload_verification.rb
+++ b/lib/smart_health_cards_test_kit/shc_payload_verification.rb
@@ -33,6 +33,7 @@ module SmartHealthCardsTestKit
           (e.g., `{"patient": {"reference": "resource:0"}}`)
     )
     input :credential_strings
+    output :fhir_bundles
 
     run do
       skip_if credential_strings.blank?, 'No Verifiable Credentials received'
@@ -79,7 +80,7 @@ module SmartHealthCardsTestKit
         end
 
         bundle = FHIR::Bundle.new(raw_bundle)
-        fhir_bundles.append(bundle)
+        fhir_bundles.append(bundle.to_hash)
         resources = bundle.entry.map(&:resource)
         bundle.entry.each { |entry| entry.resource = nil }
         resources << bundle
@@ -117,7 +118,8 @@ module SmartHealthCardsTestKit
           end
         end
       end
-      scratch[:bundles] = fhir_bundles
+
+      output fhir_bundles: fhir_bundles
     end
   end
 end

--- a/lib/smart_health_cards_test_kit/shc_payload_verification.rb
+++ b/lib/smart_health_cards_test_kit/shc_payload_verification.rb
@@ -37,7 +37,6 @@ module SmartHealthCardsTestKit
 
     run do
       skip_if credential_strings.blank?, 'No Verifiable Credentials received'
-      decompressed_payload_array = []
       fhir_bundles = []
 
       credential_strings.split(',').each do |credential|
@@ -119,7 +118,7 @@ module SmartHealthCardsTestKit
           end
         end
       end
-      output fhir_bundles: decompressed_payload_array
+      output fhir_bundles: fhir_bundles
     end
   end
 end

--- a/lib/smart_health_cards_test_kit/shc_payload_verification.rb
+++ b/lib/smart_health_cards_test_kit/shc_payload_verification.rb
@@ -33,7 +33,7 @@ module SmartHealthCardsTestKit
           (e.g., `{"patient": {"reference": "resource:0"}}`)
     )
     input :credential_strings
-    output :decompressed_payloads
+    output :fhir_bundles
 
     run do
       skip_if credential_strings.blank?, 'No Verifiable Credentials received'
@@ -117,7 +117,7 @@ module SmartHealthCardsTestKit
           end
         end
       end
-      output decompressed_payloads: decompressed_payload_array
+      output fhir_bundles: decompressed_payload_array
     end
   end
 end

--- a/lib/smart_health_cards_test_kit/shc_payload_verification.rb
+++ b/lib/smart_health_cards_test_kit/shc_payload_verification.rb
@@ -33,7 +33,6 @@ module SmartHealthCardsTestKit
           (e.g., `{"patient": {"reference": "resource:0"}}`)
     )
     input :credential_strings
-    output :fhir_bundles
 
     run do
       skip_if credential_strings.blank?, 'No Verifiable Credentials received'

--- a/lib/smart_health_cards_test_kit/shc_payload_verification.rb
+++ b/lib/smart_health_cards_test_kit/shc_payload_verification.rb
@@ -79,8 +79,10 @@ module SmartHealthCardsTestKit
                 "The following Bundle entry urls do not use short resource-scheme URIs: #{bad_urls.join(', ')}"
         end
 
+        # Have to make another copy of bundle to avoid being modified by the following codes
+        fhir_bundles.append(FHIR::Bundle.new(raw_bundle))
+
         bundle = FHIR::Bundle.new(raw_bundle)
-        fhir_bundles.append(bundle.to_json)
         resources = bundle.entry.map(&:resource)
         bundle.entry.each { |entry| entry.resource = nil }
         resources << bundle
@@ -119,7 +121,7 @@ module SmartHealthCardsTestKit
         end
       end
 
-      output fhir_bundles: fhir_bundles
+      output fhir_bundles: fhir_bundles.to_json
     end
   end
 end

--- a/lib/smart_health_cards_test_kit/shc_payload_verification.rb
+++ b/lib/smart_health_cards_test_kit/shc_payload_verification.rb
@@ -17,20 +17,6 @@ module SmartHealthCardsTestKit
       represented by the registered JWT iss claim and the issuanceDate property is represented
       by the registered JWT nbf (“not before”) claim (encoded as the number of seconds from
       1970-01-01T00:00:00Z UTC, as specified by [RFC7519](https://tools.ietf.org/html/rfc7519))
-
-      For Health Cards that will be directly represented as QR codes, issuers SHALL ensure
-      that content is minified as follows:
-      * JWS payload `.vc.credentialSubject.fhirBundle` is created...
-        * without `Resource.id` elements
-        * without `Resource.meta` elements (or if present, `.meta.security` is included and
-          no other fields are included)
-        * without `DomainResource.text` elements
-        * without `CodeableConcept.text` elements
-        * without `Coding.display` elements
-        * with `Bundle.entry.fullUrl` populated with short `resource`-scheme URIs
-          (e.g., `{"fullUrl": "resource:0"}`)
-        * with `Reference.reference` populated with short `resource`-scheme URIs
-          (e.g., `{"patient": {"reference": "resource:0"}}`)
     )
     input :credential_strings
 

--- a/lib/smart_health_cards_test_kit/shc_payload_verification.rb
+++ b/lib/smart_health_cards_test_kit/shc_payload_verification.rb
@@ -118,6 +118,7 @@ module SmartHealthCardsTestKit
           end
         end
       end
+      scratch[:bundles] = fhir_bundles
       output fhir_bundles: fhir_bundles
     end
   end

--- a/lib/smart_health_cards_test_kit/shc_payload_verification.rb
+++ b/lib/smart_health_cards_test_kit/shc_payload_verification.rb
@@ -17,6 +17,20 @@ module SmartHealthCardsTestKit
       represented by the registered JWT iss claim and the issuanceDate property is represented
       by the registered JWT nbf (“not before”) claim (encoded as the number of seconds from
       1970-01-01T00:00:00Z UTC, as specified by [RFC7519](https://tools.ietf.org/html/rfc7519))
+
+      For Health Cards that will be directly represented as QR codes, issuers SHALL ensure
+      that content is minified as follows:
+      * JWS payload `.vc.credentialSubject.fhirBundle` is created...
+        * without `Resource.id` elements
+        * without `Resource.meta` elements (or if present, `.meta.security` is included and
+          no other fields are included)
+        * without `DomainResource.text` elements
+        * without `CodeableConcept.text` elements
+        * without `Coding.display` elements
+        * with `Bundle.entry.fullUrl` populated with short `resource`-scheme URIs
+          (e.g., `{"fullUrl": "resource:0"}`)
+        * with `Reference.reference` populated with short `resource`-scheme URIs
+          (e.g., `{"patient": {"reference": "resource:0"}}`)
     )
     input :credential_strings
 

--- a/lib/smart_health_cards_test_kit/smart_health_cards_test_suite.rb
+++ b/lib/smart_health_cards_test_kit/smart_health_cards_test_suite.rb
@@ -19,25 +19,26 @@ module SmartHealthCardsTestKit
     id :smart_health_cards
     title 'SMART Health Cards'
     description %(
-      The US Core Test Kit tests systems for their conformance to the
+      The SMART Health Cards tests systems for their conformance to the
       [SMART Health Cards Framework v1.4.0](https://spec.smarthealth.cards/)
     )
 
     links [
       {
-        type: 'source_code',
-        label: 'Open Source',
-        url: 'https://github.com/inferno-framework/smart-health-cards-test-kit/'
-      },
-      {
-        type: 'report_issue',
         label: 'Report Issue',
-        url: 'https://github.com/inferno-framework/smart-health-cards-test-kit/issues/'
+        url: 'https://github.com/inferno-framework/smart-health-cards-test-kit/issues'
       },
       {
-        type: 'download',
+        label: 'Open Source',
+        url: 'https://github.com/inferno-framework/smart-health-cards-test-kit'
+      },
+      {
         label: 'Download',
-        url: 'https://github.com/inferno-framework/smart-health-cards-test-kit/releases/'
+        url: 'https://github.com/inferno-framework/smart-health-cards-test-kit/releases'
+      },
+      {
+        label: 'SMART Health Cards Framework',
+        url: 'https://spec.smarthealth.cards/'
       }
     ]
 

--- a/spec/smart_health_cards_test_kit/shc_fhir_validation_spec.rb
+++ b/spec/smart_health_cards_test_kit/shc_fhir_validation_spec.rb
@@ -121,15 +121,15 @@ RSpec.describe SmartHealthCardsTestKit::SHCFHIRValidation do
     end
 
     it 'passes if the input is an array with a single bundle conforms to the FHIR Bundle profile' do
-      fhir_bundles = [ fhir_bundle_corrina_rowe.to_hash ]
+      fhir_bundles = [ fhir_bundle_corrina_rowe.to_json ]
       result = run(test, { file_download_url: url, url: url, fhir_bundles: fhir_bundles})
       expect(result.result).to eq('pass')
     end
 
     it 'passes if the input is an array of multiple bundles that all conform to the FHIR Bundle profile' do
       fhir_bundles = [
-        fhir_bundle_corrina_rowe.to_hash,
-        fhir_bundle_deanne_gleichner.to_hash
+        fhir_bundle_corrina_rowe.to_json,
+        fhir_bundle_deanne_gleichner.to_json
       ]
       result = run(test, { file_download_url: url, url: url, fhir_bundles: fhir_bundles})
       expect(result.result).to eq('pass')

--- a/spec/smart_health_cards_test_kit/shc_fhir_validation_spec.rb
+++ b/spec/smart_health_cards_test_kit/shc_fhir_validation_spec.rb
@@ -115,8 +115,7 @@ RSpec.describe SmartHealthCardsTestKit::SHCFHIRValidation do
       )
     end
 
-    let(:test_scratch) { {}
-  }
+    let(:test_scratch) { {} }
 
     before do
       stub_request(:post, "https://example.com/validatorapi/validate")

--- a/spec/smart_health_cards_test_kit/shc_fhir_validation_spec.rb
+++ b/spec/smart_health_cards_test_kit/shc_fhir_validation_spec.rb
@@ -115,34 +115,28 @@ RSpec.describe SmartHealthCardsTestKit::SHCFHIRValidation do
       )
     end
 
-    let(:test_scratch) { {} }
-
     before do
       stub_request(:post, "https://example.com/validatorapi/validate")
         .to_return(status: 200, body: operation_outcome_success.to_json)
-
-      allow_any_instance_of(test)
-        .to receive(:scratch).and_return(test_scratch)
-      end
+    end
 
     it 'passes if the input is an array with a single bundle conforms to the FHIR Bundle profile' do
-      test_scratch[:bundles] = [ fhir_bundle_corrina_rowe ]
-      result = run(test, { file_download_url: url, url: url})
+      fhir_bundles = [ fhir_bundle_corrina_rowe.to_hash ]
+      result = run(test, { file_download_url: url, url: url, fhir_bundles: fhir_bundles})
       expect(result.result).to eq('pass')
     end
 
     it 'passes if the input is an array of multiple bundles that all conform to the FHIR Bundle profile' do
-      test_scratch[:bundles] = [
-        fhir_bundle_corrina_rowe,
-        fhir_bundle_deanne_gleichner
+      fhir_bundles = [
+        fhir_bundle_corrina_rowe.to_hash,
+        fhir_bundle_deanne_gleichner.to_hash
       ]
-      result = run(test, { file_download_url: url, url: url})
+      result = run(test, { file_download_url: url, url: url, fhir_bundles: fhir_bundles})
       expect(result.result).to eq('pass')
     end
 
     it 'skips if the no FHIR bundles received' do
-      test_scratch[:bundles] = []
-      result = run(test, { file_download_url: url, url: url})
+      result = run(test, { file_download_url: url, url: url, fhir_bundles: []})
       expect(result.result).to eq('skip')
     end
 

--- a/spec/smart_health_cards_test_kit/shc_fhir_validation_spec.rb
+++ b/spec/smart_health_cards_test_kit/shc_fhir_validation_spec.rb
@@ -35,24 +35,28 @@ RSpec.describe SmartHealthCardsTestKit::SHCFHIRValidation do
         .to_return(status: 200, body: operation_outcome_success.to_json)
     end
 
+    it 'passes for a valid fhir bundle' do
+      
+    end
+
     #TODO: update text with specific bundle type
     it 'passes if the JWS payload conforms to the FHIR Bundle profile' do
-      credential_strings = 'eyJ6aXAiOiJERUYiLCJhbGciOiJFUzI1NiIsImtpZCI6IjRIVWIyYXJ2aFRTWHNzRW9NczJHNVRvRHBzWXZzajdoNXdUXzN6TkV0dWcifQ.hVLLjtQwEPyX5pqHk5nMI0fggoQAwcIFzcFxOhMjx45sJ2JY5d9pJ7tktLuz5BLZrq6uqu57kM5BCa33fZmmygiuWuN8uWGMQQS6aqDM9hu22xd5nkUwCijvwV96hPLnXOaoznXc-ha58m0iuK3dm-UQhwPR3MYJM8o6O76KkV03aPmHe2k0nCIQFmvUXnL1bah-ofBBUtNK-wOtC5gStglLMiINt28HXStcZYMwSlFVQEZARPZCXohhUOq7VQSw6MxgBZYhgsdDINC8wwXLO6moDD5y62aesxxRh0y-ctEiNYDTRForSWbecx_6ZsddFrMszo9XtHeLpi_kjqTANEUvKsmeKHGe-8HNZrpeoccQ88iFkBrfmXrGCFNLfZ71uovz2K2DbtU-MfachnxSJ-tUjL-JQMyVkLMDTKcpgv5BFZFZbNCiDt2v8yGQEWKw81PweSe7hSLfxhkju0SrjP80dBXaEEK-2Ra7_fMEPlxP-VYM-a0YGqm5-ufgVe_KSC2C-9VwwYrtId4vpt26VLdNY9OEFRpf8pwV8yzUME-CV4r-xNH7_whz2nRYJ1I3JnUkYJ3Hjm0OBWPHReCT4D5XDu34mNvp2fvD_k_0_QU.-jNkrXCHlq75fLCGvD8_7eF4iQ-XYQT7uZyiZ1Fqa33-ZQA1-aVEk519JZYGMDdJpO-mVqIC20Xh9sBsD8COzg'
-      result = run(test, { file_download_url: url, url: url, credential_strings: credential_strings})
+      fhir_bundles = '[{"type":"collection", "entry":[{"fullUrl":"resource:0", "resource":{"name":[{"family":"Rowe", "given":["Corrina"]}], "birthDate":"1971-12-06", "resourceType":"Patient"}}, {"fullUrl":"resource:1", "resource":{"status":"completed", "vaccineCode":{"coding":[{"system":"http://hl7.org/fhir/sid/cvx", "code":"207"}]}, "patient":{"reference":"resource:0"}, "occurrenceDateTime":"2025-02-05", "lotNumber":"1234567", "resourceType":"Immunization"}}], "resourceType":"Bundle"}]'
+      result = run(test, { file_download_url: url, url: url, fhir_bundles: fhir_bundles})
       expect(result.result).to eq('pass')
     end
 
-    it 'passes if a comma-separated list of VCs all contain JWS payloads that conform to the FHIR Bundle profile' do
-      credential_strings = 'eyJ6aXAiOiJERUYiLCJhbGciOiJFUzI1NiIsImtpZCI6IjRIVWIyYXJ2aFRTWHNzRW9NczJHNVRvRHBzWXZzajdoNXdUXzN6TkV0dWcifQ.hVLLjtQwEPyX5pqHk5nMI0fggoQAwcIFzcFxOhMjx45sJ2JY5d9pJ7tktLuz5BLZrq6uqu57kM5BCa33fZmmygiuWuN8uWGMQQS6aqDM9hu22xd5nkUwCijvwV96hPLnXOaoznXc-ha58m0iuK3dm-UQhwPR3MYJM8o6O76KkV03aPmHe2k0nCIQFmvUXnL1bah-ofBBUtNK-wOtC5gStglLMiINt28HXStcZYMwSlFVQEZARPZCXohhUOq7VQSw6MxgBZYhgsdDINC8wwXLO6moDD5y62aesxxRh0y-ctEiNYDTRForSWbecx_6ZsddFrMszo9XtHeLpi_kjqTANEUvKsmeKHGe-8HNZrpeoccQ88iFkBrfmXrGCFNLfZ71uovz2K2DbtU-MfachnxSJ-tUjL-JQMyVkLMDTKcpgv5BFZFZbNCiDt2v8yGQEWKw81PweSe7hSLfxhkju0SrjP80dBXaEEK-2Ra7_fMEPlxP-VYM-a0YGqm5-ufgVe_KSC2C-9VwwYrtId4vpt26VLdNY9OEFRpf8pwV8yzUME-CV4r-xNH7_whz2nRYJ1I3JnUkYJ3Hjm0OBWPHReCT4D5XDu34mNvp2fvD_k_0_QU.-jNkrXCHlq75fLCGvD8_7eF4iQ-XYQT7uZyiZ1Fqa33-ZQA1-aVEk519JZYGMDdJpO-mVqIC20Xh9sBsD8COzg,eyJ6aXAiOiJERUYiLCJhbGciOiJFUzI1NiIsImtpZCI6IjRIVWIyYXJ2aFRTWHNzRW9NczJHNVRvRHBzWXZzajdoNXdUXzN6TkV0dWcifQ.fZDBTsMwEET_ZbkmaUJatfURVT0jFbigHhxnWxs5drV2IoUq_866oUJCAt_WfjOe2SuYEECAjvEiFgvrlbTahyjqsiwhA9ecQFTruqrrzWa1zGBQIK4QxwuCeL_JAutCJylqlDbqQklqw8M85Glgm7855QfTVtt_GdN1vTOfMhrv4JiBImzRRSPtoW8-UMUU6aQNvSGFxAhYFmVRsWm6fepda_EnNihvLasSmQEb0chd2KG39pUsA4TB96RQpBXch2TgZIczKztjWQZ7EzQSY2czoEs7OXiSo4TjxEkbw1V2MqZfq-3jKi_X-a3s3fRlTvTM3TgITEn06-07_sTnCw.pYwsdxlzdXVhnPzO_YDlMXnSHHz88XA3A9bGuzutySq2v3tO5lOWsfsOQGhoWiH7LCtUNpoizX5GSi5cXVI19g'
-      result = run(test, { file_download_url: url, url: url, credential_strings: credential_strings})
+    #it 'passes if a comma-separated list of VCs all contain JWS payloads that conform to the FHIR Bundle profile' do
+    #  credential_strings = 'eyJ6aXAiOiJERUYiLCJhbGciOiJFUzI1NiIsImtpZCI6IjRIVWIyYXJ2aFRTWHNzRW9NczJHNVRvRHBzWXZzajdoNXdUXzN6TkV0dWcifQ.hVLLjtQwEPyX5pqHk5nMI0fggoQAwcIFzcFxOhMjx45sJ2JY5d9pJ7tktLuz5BLZrq6uqu57kM5BCa33fZmmygiuWuN8uWGMQQS6aqDM9hu22xd5nkUwCijvwV96hPLnXOaoznXc-ha58m0iuK3dm-UQhwPR3MYJM8o6O76KkV03aPmHe2k0nCIQFmvUXnL1bah-ofBBUtNK-wOtC5gStglLMiINt28HXStcZYMwSlFVQEZARPZCXohhUOq7VQSw6MxgBZYhgsdDINC8wwXLO6moDD5y62aesxxRh0y-ctEiNYDTRForSWbecx_6ZsddFrMszo9XtHeLpi_kjqTANEUvKsmeKHGe-8HNZrpeoccQ88iFkBrfmXrGCFNLfZ71uovz2K2DbtU-MfachnxSJ-tUjL-JQMyVkLMDTKcpgv5BFZFZbNCiDt2v8yGQEWKw81PweSe7hSLfxhkju0SrjP80dBXaEEK-2Ra7_fMEPlxP-VYM-a0YGqm5-ufgVe_KSC2C-9VwwYrtId4vpt26VLdNY9OEFRpf8pwV8yzUME-CV4r-xNH7_whz2nRYJ1I3JnUkYJ3Hjm0OBWPHReCT4D5XDu34mNvp2fvD_k_0_QU.-jNkrXCHlq75fLCGvD8_7eF4iQ-XYQT7uZyiZ1Fqa33-ZQA1-aVEk519JZYGMDdJpO-mVqIC20Xh9sBsD8COzg,eyJ6aXAiOiJERUYiLCJhbGciOiJFUzI1NiIsImtpZCI6IjRIVWIyYXJ2aFRTWHNzRW9NczJHNVRvRHBzWXZzajdoNXdUXzN6TkV0dWcifQ.fZDBTsMwEET_ZbkmaUJatfURVT0jFbigHhxnWxs5drV2IoUq_866oUJCAt_WfjOe2SuYEECAjvEiFgvrlbTahyjqsiwhA9ecQFTruqrrzWa1zGBQIK4QxwuCeL_JAutCJylqlDbqQklqw8M85Glgm7855QfTVtt_GdN1vTOfMhrv4JiBImzRRSPtoW8-UMUU6aQNvSGFxAhYFmVRsWm6fepda_EnNihvLasSmQEb0chd2KG39pUsA4TB96RQpBXch2TgZIczKztjWQZ7EzQSY2czoEs7OXiSo4TjxEkbw1V2MqZfq-3jKi_X-a3s3fRlTvTM3TgITEn06-07_sTnCw.pYwsdxlzdXVhnPzO_YDlMXnSHHz88XA3A9bGuzutySq2v3tO5lOWsfsOQGhoWiH7LCtUNpoizX5GSi5cXVI19g'
+    #  result = run(test, { file_download_url: url, url: url, credential_strings: credential_strings})
 
-      expect(result.result).to eq('pass')
-    end
+    #  expect(result.result).to eq('pass')
+    #end
 
-    it 'raises an error if the JWS payload does not conform to the FHIR Bundle profile' do
-      credential_strings = 'asdf'
-      expect {result = run(test, { file_download_url: url, url: url, credential_strings: credential_strings })}.to raise_error()
-    end
+    #it 'raises an error if the JWS payload does not conform to the FHIR Bundle profile' do
+    #  credential_strings = 'asdf'
+    #  expect {result = run(test, { file_download_url: url, url: url, credential_strings: credential_strings })}.to raise_error()
+    #end
 
   end
 

--- a/spec/smart_health_cards_test_kit/shc_fhir_validation_spec.rb
+++ b/spec/smart_health_cards_test_kit/shc_fhir_validation_spec.rb
@@ -121,22 +121,22 @@ RSpec.describe SmartHealthCardsTestKit::SHCFHIRValidation do
     end
 
     it 'passes if the input is an array with a single bundle conforms to the FHIR Bundle profile' do
-      fhir_bundles = [ fhir_bundle_corrina_rowe.to_json ]
+      fhir_bundles = [ fhir_bundle_corrina_rowe ].to_json
       result = run(test, { file_download_url: url, url: url, fhir_bundles: fhir_bundles})
       expect(result.result).to eq('pass')
     end
 
     it 'passes if the input is an array of multiple bundles that all conform to the FHIR Bundle profile' do
       fhir_bundles = [
-        fhir_bundle_corrina_rowe.to_json,
-        fhir_bundle_deanne_gleichner.to_json
-      ]
+        fhir_bundle_corrina_rowe,
+        fhir_bundle_deanne_gleichner
+    ].to_json
       result = run(test, { file_download_url: url, url: url, fhir_bundles: fhir_bundles})
       expect(result.result).to eq('pass')
     end
 
     it 'skips if the no FHIR bundles received' do
-      result = run(test, { file_download_url: url, url: url, fhir_bundles: []})
+      result = run(test, { file_download_url: url, url: url, fhir_bundles: [].to_json})
       expect(result.result).to eq('skip')
     end
 

--- a/spec/smart_health_cards_test_kit/shc_fhir_validation_spec.rb
+++ b/spec/smart_health_cards_test_kit/shc_fhir_validation_spec.rb
@@ -29,6 +29,47 @@ RSpec.describe SmartHealthCardsTestKit::SHCFHIRValidation do
         sessionId: 'b8cf5547-1dc7-4714-a797-dc2347b93fe2'
       }
     end
+    let(:fhir_bundles) do
+      FHIR::Bundle.new(
+        type: 'collection',
+        entry: [
+          {
+            fullUrl: 'resource:0',
+            resource: {
+              name: [
+                {
+                  family: 'Rowe',
+                  given: ['Corrina']
+                }
+              ],
+              birthDate: '1971-12-06',
+              resourceType: 'Patient'
+            }
+          },
+          {
+            fullUrl: 'resource:1',
+            resource: {
+              status: 'completed',
+              vaccineCode: {
+                coding: [
+                  {
+                    system: 'http://hl7.org/fhir/sid/cvx',
+                    code: '207'
+                  }
+                ]
+              },
+              patient: {
+                reference: 'resource:0'
+              },
+              occurrenceDateTime: '2025-02-05',
+              lotNumber: '1234567',
+              resourceType: 'Immunization'
+            }
+          }
+        ],
+        resourceType: 'Bundle'
+      )
+    end
 
     before do
       stub_request(:post, "https://example.com/validatorapi/validate")
@@ -36,13 +77,12 @@ RSpec.describe SmartHealthCardsTestKit::SHCFHIRValidation do
     end
 
     it 'passes for a valid fhir bundle' do
-      
+
     end
 
     #TODO: update text with specific bundle type
     it 'passes if the JWS payload conforms to the FHIR Bundle profile' do
-      fhir_bundles = '[{"type":"collection", "entry":[{"fullUrl":"resource:0", "resource":{"name":[{"family":"Rowe", "given":["Corrina"]}], "birthDate":"1971-12-06", "resourceType":"Patient"}}, {"fullUrl":"resource:1", "resource":{"status":"completed", "vaccineCode":{"coding":[{"system":"http://hl7.org/fhir/sid/cvx", "code":"207"}]}, "patient":{"reference":"resource:0"}, "occurrenceDateTime":"2025-02-05", "lotNumber":"1234567", "resourceType":"Immunization"}}], "resourceType":"Bundle"}]'
-      result = run(test, { file_download_url: url, url: url, fhir_bundles: fhir_bundles})
+      result = run(test, { file_download_url: url, url: url, fhir_bundles: [ fhir_bundles.to_hash ]})
       expect(result.result).to eq('pass')
     end
 

--- a/spec/smart_health_cards_test_kit/shc_fhir_validation_spec.rb
+++ b/spec/smart_health_cards_test_kit/shc_fhir_validation_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe SmartHealthCardsTestKit::SHCFHIRValidation do
         sessionId: 'b8cf5547-1dc7-4714-a797-dc2347b93fe2'
       }
     end
-    let(:fhir_bundles) do
+    let(:fhir_bundle_corrina_rowe) do
       FHIR::Bundle.new(
         type: 'collection',
         entry: [
@@ -71,33 +71,72 @@ RSpec.describe SmartHealthCardsTestKit::SHCFHIRValidation do
       )
     end
 
+    let (:fhir_bundle_deanne_gleichner) do
+      FHIR::Bundle.new(
+        type: 'collection',
+        entry: [
+          {
+            fullUrl: 'resource:0',
+            resource: {
+              name: [
+                {
+                  family: 'Gleichner',
+                  given: [
+                    'Deanne'
+                  ]
+                }
+              ],
+              birthDate: '2007-04-11',
+              resourceType: 'Patient'
+            }
+          },
+          {
+            fullUrl: 'resource:1',
+            resource: {
+              status: 'completed',
+              vaccineCode: {
+                coding: [
+                  {
+                    system: 'http://hl7.org/fhir/sid/cvx',
+                    code: '210'
+                  }
+                ]
+              },
+              patient: {
+                reference: 'resource:0'
+              },
+              occurrenceDateTime: '2025-02-04',
+              lotNumber: '1234567',
+              resourceType: 'Immunization'
+            }
+          }
+        ],
+        resourceType: 'Bundle'
+      )
+    end
+
     before do
       stub_request(:post, "https://example.com/validatorapi/validate")
         .to_return(status: 200, body: operation_outcome_success.to_json)
     end
 
-    it 'passes for a valid fhir bundle' do
-
-    end
-
-    #TODO: update text with specific bundle type
-    it 'passes if the JWS payload conforms to the FHIR Bundle profile' do
-      result = run(test, { file_download_url: url, url: url, fhir_bundles: [ fhir_bundles.to_hash ]})
+    it 'passes if the input is an array with a single bundle conforms to the FHIR Bundle profile' do
+      result = run(test, { file_download_url: url, url: url, fhir_bundles: [ fhir_bundle_corrina_rowe.to_hash ]})
       expect(result.result).to eq('pass')
     end
 
-    #it 'passes if a comma-separated list of VCs all contain JWS payloads that conform to the FHIR Bundle profile' do
-    #  credential_strings = 'eyJ6aXAiOiJERUYiLCJhbGciOiJFUzI1NiIsImtpZCI6IjRIVWIyYXJ2aFRTWHNzRW9NczJHNVRvRHBzWXZzajdoNXdUXzN6TkV0dWcifQ.hVLLjtQwEPyX5pqHk5nMI0fggoQAwcIFzcFxOhMjx45sJ2JY5d9pJ7tktLuz5BLZrq6uqu57kM5BCa33fZmmygiuWuN8uWGMQQS6aqDM9hu22xd5nkUwCijvwV96hPLnXOaoznXc-ha58m0iuK3dm-UQhwPR3MYJM8o6O76KkV03aPmHe2k0nCIQFmvUXnL1bah-ofBBUtNK-wOtC5gStglLMiINt28HXStcZYMwSlFVQEZARPZCXohhUOq7VQSw6MxgBZYhgsdDINC8wwXLO6moDD5y62aesxxRh0y-ctEiNYDTRForSWbecx_6ZsddFrMszo9XtHeLpi_kjqTANEUvKsmeKHGe-8HNZrpeoccQ88iFkBrfmXrGCFNLfZ71uovz2K2DbtU-MfachnxSJ-tUjL-JQMyVkLMDTKcpgv5BFZFZbNCiDt2v8yGQEWKw81PweSe7hSLfxhkju0SrjP80dBXaEEK-2Ra7_fMEPlxP-VYM-a0YGqm5-ufgVe_KSC2C-9VwwYrtId4vpt26VLdNY9OEFRpf8pwV8yzUME-CV4r-xNH7_whz2nRYJ1I3JnUkYJ3Hjm0OBWPHReCT4D5XDu34mNvp2fvD_k_0_QU.-jNkrXCHlq75fLCGvD8_7eF4iQ-XYQT7uZyiZ1Fqa33-ZQA1-aVEk519JZYGMDdJpO-mVqIC20Xh9sBsD8COzg,eyJ6aXAiOiJERUYiLCJhbGciOiJFUzI1NiIsImtpZCI6IjRIVWIyYXJ2aFRTWHNzRW9NczJHNVRvRHBzWXZzajdoNXdUXzN6TkV0dWcifQ.fZDBTsMwEET_ZbkmaUJatfURVT0jFbigHhxnWxs5drV2IoUq_866oUJCAt_WfjOe2SuYEECAjvEiFgvrlbTahyjqsiwhA9ecQFTruqrrzWa1zGBQIK4QxwuCeL_JAutCJylqlDbqQklqw8M85Glgm7855QfTVtt_GdN1vTOfMhrv4JiBImzRRSPtoW8-UMUU6aQNvSGFxAhYFmVRsWm6fepda_EnNihvLasSmQEb0chd2KG39pUsA4TB96RQpBXch2TgZIczKztjWQZ7EzQSY2czoEs7OXiSo4TjxEkbw1V2MqZfq-3jKi_X-a3s3fRlTvTM3TgITEn06-07_sTnCw.pYwsdxlzdXVhnPzO_YDlMXnSHHz88XA3A9bGuzutySq2v3tO5lOWsfsOQGhoWiH7LCtUNpoizX5GSi5cXVI19g'
-    #  result = run(test, { file_download_url: url, url: url, credential_strings: credential_strings})
+    it 'passes if the input is an array of multiple bundles that all conform to the FHIR Bundle profile' do
+      fhir_bundles = []
+      fhir_bundles.append(fhir_bundle_corrina_rowe.to_hash)
+      fhir_bundles.append(fhir_bundle_deanne_gleichner.to_hash)
+      result = run(test, { file_download_url: url, url: url, fhir_bundles: fhir_bundles})
+      expect(result.result).to eq('pass')
+    end
 
-    #  expect(result.result).to eq('pass')
-    #end
-
-    #it 'raises an error if the JWS payload does not conform to the FHIR Bundle profile' do
-    #  credential_strings = 'asdf'
-    #  expect {result = run(test, { file_download_url: url, url: url, credential_strings: credential_strings })}.to raise_error()
-    #end
+    it 'raises an error if the input does not conform to the FHIR Bundle profile' do
+      result = run(test, { file_download_url: url, url: url, fhir_bundles: 'asdf'})
+      expect(result.result).to eq('error')
+    end
 
   end
-
 end

--- a/spec/smart_health_cards_test_kit/shc_fhir_validation_spec.rb
+++ b/spec/smart_health_cards_test_kit/shc_fhir_validation_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe SmartHealthCardsTestKit::SHCFHIRValidation do
         entry: [
           {
             fullUrl: 'resource:0',
-            resource: {
+            resource: FHIR::Patient.new(
               name: [
                 {
                   family: 'Rowe',
@@ -44,11 +44,11 @@ RSpec.describe SmartHealthCardsTestKit::SHCFHIRValidation do
               ],
               birthDate: '1971-12-06',
               resourceType: 'Patient'
-            }
+            )
           },
           {
             fullUrl: 'resource:1',
-            resource: {
+            resource: FHIR::Immunization.new(
               status: 'completed',
               vaccineCode: {
                 coding: [
@@ -64,7 +64,7 @@ RSpec.describe SmartHealthCardsTestKit::SHCFHIRValidation do
               occurrenceDateTime: '2025-02-05',
               lotNumber: '1234567',
               resourceType: 'Immunization'
-            }
+            )
           }
         ],
         resourceType: 'Bundle'
@@ -77,7 +77,7 @@ RSpec.describe SmartHealthCardsTestKit::SHCFHIRValidation do
         entry: [
           {
             fullUrl: 'resource:0',
-            resource: {
+            resource: FHIR::Patient.new(
               name: [
                 {
                   family: 'Gleichner',
@@ -88,11 +88,11 @@ RSpec.describe SmartHealthCardsTestKit::SHCFHIRValidation do
               ],
               birthDate: '2007-04-11',
               resourceType: 'Patient'
-            }
+            )
           },
           {
             fullUrl: 'resource:1',
-            resource: {
+            resource: FHIR::Immunization.new(
               status: 'completed',
               vaccineCode: {
                 coding: [
@@ -108,7 +108,7 @@ RSpec.describe SmartHealthCardsTestKit::SHCFHIRValidation do
               occurrenceDateTime: '2025-02-04',
               lotNumber: '1234567',
               resourceType: 'Immunization'
-            }
+            )
           }
         ],
         resourceType: 'Bundle'


### PR DESCRIPTION
# Summary

This PR addresses JIRA ticket FI-3759. The main change in this PR is swtich the input of shc_fhir_validation module from array of credential strings to array of FHIR Bundles saved in hash input paraemter. The main reason behind this change is to avoid redo the decoding of credential strings in mulitple places, and this also reduce the work for unit testing so that unit test does not depend on encoded credential string.

Also rebased to Ruby v3.3.6

This PR also address these two tickets:

FI-3636: fix typo and update links in test kit description 
FI-3723: Add note that DeepLink download is currently not supported.


# Testing Guidance
Pass All Unit tests
Pass All Integration tests

